### PR TITLE
i18n fixes for lang generation

### DIFF
--- a/tool/i18n/.gitignore
+++ b/tool/i18n/.gitignore
@@ -10,3 +10,4 @@ outputs
 .DS_Store
 static/
 .idea/*
+vendor/

--- a/tool/i18n/cmd/flutter.go
+++ b/tool/i18n/cmd/flutter.go
@@ -25,7 +25,7 @@ var flutterCmd = &cobra.Command{
 		if *template == "" {
 			return services.GenerateMultiLanguagesArbFilesFromJSONFiles(*dir, *prefixName, "json", "arb", *full)
 		}
-		return services.GenerateMultiLanguageFilesFromTemplate(*template, *dir, *prefixName, "json", "==", getLanguages(*languages, ","), *full)
+		return services.GenerateMultiLanguageFilesFromTemplate(*template, *dir, *prefixName, "json", " ", getLanguages(*languages, ","), *full)
 	},
 }
 

--- a/tool/i18n/examples/i18n_example/Makefile
+++ b/tool/i18n/examples/i18n_example/Makefile
@@ -38,6 +38,7 @@ lang-dep: ## lang-dep
 lang-gen-flu: ## lang-gen-flu
 	@mkdir -p $(I18N_GENERATED_DIR)
 	@mkdir -p $(I18N_DIR)
+	@curl "https://raw.githubusercontent.com/getcouragenow/packages/master/mod-main/client/lib/core/i18n/translations.dart" > $(I18N_LOCALIZATION_DIR)/translations.dart
 	@flutter pub run intl_translation:extract_to_arb --output-dir=$(I18N_DIR) $(I18N_LOCALIZATION_DIR)/translations.dart
 	@i18n flutter --dir $(I18N_DIR) --template $(I18N_TEMPLATE_PATH) --prefix $(I18N_PREFIX_OUT_FILES) --languages $(I18N_SUPPORTED_LANGUAGES) -f
 	@i18n flutter --dir $(I18N_DIR)

--- a/tool/i18n/examples/intl.arb
+++ b/tool/i18n/examples/intl.arb
@@ -1,14 +1,14 @@
 {
-	"title": "Goodmorning",
+	"title": "Good Morning",
 	"@title": {
-	  "description": "",
-	  "type": "",
-	  "placeholders": {}
+		"description": "",
+		"type": "",
+		"placeholders": {}
 	},
 	"title1": "Good",
 	"@title1": {
-	  "description": "",
-	  "type": "",
-	  "placeholders": {}
+		"description": "",
+		"type": "",
+		"placeholders": {}
 	}
 }

--- a/tool/i18n/go.sum
+++ b/tool/i18n/go.sum
@@ -27,7 +27,6 @@ github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
-github.com/getcouragenow/bootstrap v0.0.0-20200219164813-03b382fcbb1f h1:f/1U71vjn8xXNb9gvq98+sCnaWHek8HZN2UI42m44tw=
 github.com/getcouragenow/bootstrap/tool/googlesheet v0.0.0-20200216153739-62b1c832988f h1:RSgMFvAj4uzmQptR58KHUx+GMAem+1GaW4B+2Qf4fww=
 github.com/getcouragenow/bootstrap/tool/googlesheet v0.0.0-20200216153739-62b1c832988f/go.mod h1:bvRXnXD8Lu33WEVd4DS2DDtA9Y89V5qYBcRKZnikukE=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/tool/i18n/services/config/config.go
+++ b/tool/i18n/services/config/config.go
@@ -94,6 +94,7 @@ func New(option string) (*Settings, error) {
 
 	}
 	return &Settings{
-			GoogleSheet: configs},
+			GoogleSheet: configs,
+		},
 		nil
 }

--- a/tool/i18n/services/file.go
+++ b/tool/i18n/services/file.go
@@ -87,7 +87,7 @@ func tomlFiles(csvFileContent [][]string, config config.Config, cleanTagsDir, cl
 	for index, col := range csvFileContent[0][1:] {
 
 		cache := make(map[string]int)
-		languages := []TomlFormat{}
+		var languages []TomlFormat
 		cleanedData := ""
 		fileName := getOutFileName(config.FileName, col)
 		index++
@@ -155,10 +155,10 @@ func tomlFiles(csvFileContent [][]string, config config.Config, cleanTagsDir, cl
 	return nil
 }
 
-// JSONify allows to convert linkedhashmap.Map with a max deep of two to json
+// JSONify allows to convert linkedhashmap.Map with a max depth of two to json
 // Todo make it recursive
 func jsonify(m *linkedhashmap.Map) ([]byte, error) {
-	var b = []byte{}
+	var b []byte
 	buf := bytes.NewBuffer(b)
 
 	buf.WriteRune('{')

--- a/tool/i18n/services/parse_test.go
+++ b/tool/i18n/services/parse_test.go
@@ -1,11 +1,13 @@
-package services
+package services_test
 
 import (
-	"fmt"
+	"github.com/getcouragenow/bootstrap/tool/i18n/services"
+	"io/ioutil"
 	"testing"
 )
 
-var data = []byte(`
+var (
+	data = []byte(`
 {
 	"title": "Good morning",
 	"@title": {
@@ -22,11 +24,42 @@ var data = []byte(`
   }
   
 `)
+)
+
+const (
+	success = "\u2713"
+	failed  = "\u274c"
+)
 
 func TestTranslate(t *testing.T) {
-	fmt.Println(GenerateMultiLanguageFilesFromTemplate("intl.arb", "", "out", ".json", "==", []string{"fr", "es"}, false))
+	if err := ioutil.WriteFile("/tmp/data.arb", data, 0644); err != nil {
+		t.Fatalf("\t%s\tShould be able to write data file to /tmp: %v", failed, err)
+	}
+	// fmt.Println(GenerateMultiLanguageFilesFromTemplate("../examples/intl.arb", "", "out", ".json", "==", []string{"fr", "es"}, false))
+	t.Run("Test Multi Languages Files From Template", testGenerateMultiLanguageFilesFromTemplate)
 }
 
-func TestGenerateMultiLanguagesFilesFromFiles(t *testing.T) {
-	// fmt.Println(GenerateMultiLanguagesFilesFromFiles(".", ".", "json", "arb", false))
+func testGenerateMultiLanguageFilesFromTemplate(t *testing.T) {
+	t.Log("Test multi language files from template")
+	{
+		err := services.GenerateMultiLanguageFilesFromTemplate(
+			"/tmp/data.arb",
+			"/tmp",
+			"out",
+			".json",
+			"==",
+			[]string{"fr", "es"},
+			false,
+		)
+		if err != nil {
+			t.Fatalf(
+				"\t%s\tShould be able to write translated output files to /tmp, got: %v",
+				failed,
+				err,
+			)
+		}
+		t.Logf("\t%s\tShould be able to write translated output files to /tmp",
+			success)
+	}
 }
+

--- a/tool/i18n/services/translation.go
+++ b/tool/i18n/services/translation.go
@@ -32,7 +32,7 @@ type ArbAttr struct {
 func getTemplateWords(m *linkedhashmap.Map, delay time.Duration, tries int, fromLang, sep string, languages []string) ([]Translate, error) {
 
 	words := getTranslateWords(m, sep)
-	wordsTranslated := []Translate{}
+	var wordsTranslated []Translate
 	for _, lang := range languages {
 
 		t := Translate{}
@@ -82,7 +82,7 @@ func getTranslatedMaps(sep string, WordsTranslated []Translate, m *linkedhashmap
 func getTranslateWords(m *linkedhashmap.Map, sep string) string {
 	it := m.Iterator()
 
-	out := []string{}
+	var out []string
 	for it.Next() {
 		if !strings.HasPrefix(it.Key().(string), "@") {
 			v, ok := it.Value().(string)

--- a/tool/i18n/services/write.go
+++ b/tool/i18n/services/write.go
@@ -148,8 +148,8 @@ func WriteLanguageFiles(csvFilePath string, jsonDirPath string, sheet string) er
 		return errors.Wrap(err, sheet+" : "+"Cannot open file: \""+langAbsPath+"\"")
 	}
 
-	//log.Println("langAbsPath: \"" + langAbsPath + "\"")
-	//os.Exit(1)
+	// log.Println("langAbsPath: \"" + langAbsPath + "\"")
+	// os.Exit(1)
 
 	err = file.Truncate(0)
 	if err != nil {
@@ -275,6 +275,16 @@ func GenerateMultiLanguagesArbFilesFromJSONFiles(dir, prefix, extFile, outExtFil
 	}
 	return nil
 }
+
+// mlOutputConfig is the output configuration for GenerateMultiLanguageFilesFromTemplate
+// type mlOutputConfig struct {
+// 	templatePath string // template arb filepath
+// 	outPath      string // output path
+// 	ext          string // extension name
+// 	separator string // separator for template words
+// 	languages []string // languages to generate
+// 	full bool //
+// }
 
 // GenerateMultiLanguageFilesFromTemplate write multilanguage json files
 func GenerateMultiLanguageFilesFromTemplate(templatePath, outPath, fileName, ext, sep string, languages []string, full bool) error {

--- a/tool/i18n/utils/translation.go
+++ b/tool/i18n/utils/translation.go
@@ -13,7 +13,7 @@ type CleanTranslation struct {
 }
 
 // CleanData clean data by replacing errors during translation
-func CleanData(data string, tagsFileDir, tagsFileName string) string {
+func CleanData(data, tagsFileDir, tagsFileName string) string {
 	cleanedData := data
 
 	cleanTags, _ := GetCleanTranslationTags(tagsFileDir, tagsFileName)


### PR DESCRIPTION
Fixes  #71 

TODO:
1. cleans up input 
2. Make sure everything really works by adding equality tests via `google/go-cmp`